### PR TITLE
Ship using container image

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,16 @@
+.dockerignore
+.git
+!.git/HEAD
+!.git/refs
+/cover/
+/doc/
+/test/
+/tmp/
+.elixir_ls
+/_build/
+/deps/
+*.ez
+erl_crash.dump
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,50 @@
+ARG ELIXIR_VERSION=1.17.2
+ARG OTP_VERSION=27.0.1
+ARG ALPINE_VERSION=3.20.3
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_VERSION}"
+ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
+
+FROM ${BUILDER_IMAGE} as builder
+
+RUN apk add --no-cache build-base git python3 curl
+
+WORKDIR /app
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+ENV MIX_ENV="prod"
+
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+
+COPY priv priv
+COPY lib lib
+COPY assets assets
+
+RUN mix assets.deploy
+RUN mix compile
+
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+FROM ${RUNNER_IMAGE}
+
+RUN apk add --no-cache libstdc++ openssl ncurses-libs
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+ENV MIX_ENV="prod"
+
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/mse25 ./
+
+USER nobody
+
+CMD ["/app/bin/server"]


### PR DESCRIPTION
This PR will add a `Containerfile` to make it possible to deploy to production using a container image.

A `.containerignore` is also added.