### PR TITLE
List and show events

### DIFF
--- a/lib/mse25/directus.ex
+++ b/lib/mse25/directus.ex
@@ -25,19 +25,19 @@ defmodule Mse25.Directus do
     get("/articles?" <> params)
   end
 
-  def get_event(slug) do
+  def get_album(externalId) do
     get_item(
-      :events,
-      slug,
+      :albums,
+      externalId,
       [
-        "*",
-        "location.*",
-        "poster.filename_download",
-        "poster.width",
-        "poster.height",
-        "bands.artists_id.name",
-        "mia.artists_id.name",
-        "location.name"
+        "purchased_at",
+        "album",
+        "year",
+        "youtubeId",
+        "externalId",
+        "cover",
+        "songs.title",
+        "songs.artist.name"
       ]
       |> Enum.join(",")
     )
@@ -71,21 +71,19 @@ defmodule Mse25.Directus do
     end)
   end
 
-  def get_album(externalId) do
+  def get_event(slug) do
     get_item(
-      :albums,
-      externalId,
+      :events,
+      slug,
       [
-        "purchased_at",
-        "album",
-        "year",
-        "youtubeId",
-        "externalId",
-        "cover.filename_download",
-        "cover.width",
-        "cover.height",
-        "songs.title",
-        "songs.artist.name"
+        "*",
+        "location.*",
+        "poster.filename_download",
+        "poster.width",
+        "poster.height",
+        "bands.artists_id.name",
+        "mia.artists_id.name",
+        "location.name"
       ]
       |> Enum.join(",")
     )
@@ -108,9 +106,8 @@ defmodule Mse25.Directus do
               "title",
               "lead",
               "slug",
-              "poster.filename_download",
-              "poster.width",
-              "poster.height",
+              "poster",
+              "category",
               "bands.artists_id.name",
               "mia.artists_id.name"
             ],
@@ -218,7 +215,7 @@ defmodule Mse25.Directus do
     case opts[:query] do
       nil -> params
       "" -> params
-      pg -> ["filter[title][_icontains]=" <> to_string(pg) | params]
+      pg -> ["filter[title][_icontains]=" <> String.replace(to_string(pg), " ", "%20") | params]
     end
   end
 end

--- a/lib/mse25/directus.ex
+++ b/lib/mse25/directus.ex
@@ -78,12 +78,9 @@ defmodule Mse25.Directus do
       [
         "*",
         "location.*",
-        "poster.filename_download",
-        "poster.width",
-        "poster.height",
+        "poster",
         "bands.artists_id.name",
-        "mia.artists_id.name",
-        "location.name"
+        "mia.artists_id.name"
       ]
       |> Enum.join(",")
     )

--- a/lib/mse25/event_helpers.ex
+++ b/lib/mse25/event_helpers.ex
@@ -1,4 +1,4 @@
-defmodule Mse25.Utils do
+defmodule Mse25.EventHelpers do
   def bandlist(bands) do
     bands
     |> Enum.map(fn b -> b["artists_id"]["name"] end)

--- a/lib/mse25/utils.ex
+++ b/lib/mse25/utils.ex
@@ -1,0 +1,33 @@
+defmodule Mse25.Utils do
+  def bandlist(bands) do
+    bands
+    |> Enum.map(fn b -> b["artists_id"]["name"] end)
+    |> Enum.join(", ")
+    |> String.replace(~r/, ([^,]+?)$/, " och \\1")
+  end
+
+  def hilights?(%{"bands" => bands, "category" => category}) do
+    _festival_band?(bands, category)
+  end
+
+  def missed?(%{"mia" => bands, "category" => category}) do
+    _festival_band?(bands, category)
+  end
+
+  def opening_acts?(%{"bands" => [_ | bands], "category" => "concert"}) do
+    not Enum.empty?(bands)
+  end
+
+  def opening_acts?(_) do
+    false
+  end
+
+  def _festival_band?(bands, category)
+      when category in ["cruise", "openairfestival", "cityfestival", "onedayfestival"] do
+    not Enum.empty?(bands)
+  end
+
+  def _festival_band?(_b, _c) do
+    false
+  end
+end

--- a/lib/mse25_web/controllers/item_controller.ex
+++ b/lib/mse25_web/controllers/item_controller.ex
@@ -67,16 +67,23 @@ defmodule Mse25Web.ItemController do
   defp assigns(:event, %{
          "title" => heading,
          "contents" => contents,
-         "started_at" => published_at,
-         "lead" => lead
+         "started_at" => started_at,
+         "lead" => lead,
+         "poster" => poster,
+         "bands" => bands,
+         "mia" => mia,
+         "category" => category
        }) do
     [
       page_title: heading,
       heading: heading,
       contents: Earmark.as_html!(contents),
-      published_at: published_at,
       lead: lead,
-      year: String.slice(published_at, 0..3)
+      year: String.slice(started_at, 0..3),
+      poster: poster,
+      bands: bands,
+      mia: mia,
+      category: category
     ]
   end
 

--- a/lib/mse25_web/controllers/item_html.ex
+++ b/lib/mse25_web/controllers/item_html.ex
@@ -1,5 +1,7 @@
 defmodule Mse25Web.ItemHTML do
   use Mse25Web, :html
 
+  import Mse25.Utils
+
   embed_templates "item_html/*"
 end

--- a/lib/mse25_web/controllers/item_html.ex
+++ b/lib/mse25_web/controllers/item_html.ex
@@ -1,7 +1,6 @@
 defmodule Mse25Web.ItemHTML do
   use Mse25Web, :html
-
-  import Mse25.Utils
+  import Mse25.EventHelpers
 
   embed_templates "item_html/*"
 end

--- a/lib/mse25_web/controllers/item_html/event.html.heex
+++ b/lib/mse25_web/controllers/item_html/event.html.heex
@@ -1,9 +1,45 @@
-<article>
-<header>
-<date><%= @published_at %></date>
-<h1><%= @heading %></h1>
-</header>
+<article class="article">
+  <header>
+    <ol class="breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
+      <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+        <a href="/" rel="home">
+          <span itemprop="name">madr.se</span>
+        </a>
+        <meta itemprop="position" content="1" />
+      </li>
+      <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+        <a href="/evenemang">
+          <span itemprop="name">Evenemang</span>
+        </a>
+        <meta itemprop="position" content="2" />
+      </li>
+      <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+        <a href={"/" <> @year}>
+          <span itemprop="name"><%= @year %></span>
+        </a>
+        <meta itemprop="position" content="3" />
+      </li>
+    </ol>
+    <h1><%= @heading %></h1>
+  </header>
 
-<%= raw @contents %>
+  <ul>
+    <li><%= @lead %></li>
+    <%= if opening_acts?(%{"bands" => @bands, "category" => @category}) do %>
+      <li>Huvudakt: <%= @bands |> List.first() |> Map.get("artists_id") |> Map.get("name") %></li>
+      <li>Förband: <%= @bands |> Enum.drop(1) |> bandlist() %></li>
+    <% end %>
+    <%= if hilights?(%{"bands" => @bands, "category" => @category}) do %>
+      <li>Personliga höjdpunkter: <%= @bands |> bandlist() %></li>
+    <% end %>
+    <%= if missed?(%{"mia" => @mia, "category" => @category}) do %>
+      <li>Band jag missade: <%= @mia |> bandlist() %></li>
+    <% end %>
+  </ul>
 
+  <%= raw(@contents) %>
+
+  <%= if @poster do %>
+    <img src={"https://n.madr.se/assets/" <> @poster} alt="affisch" loading="lazy" />
+  <% end %>
 </article>

--- a/lib/mse25_web/controllers/page_controller.ex
+++ b/lib/mse25_web/controllers/page_controller.ex
@@ -20,9 +20,9 @@ defmodule Mse25Web.PageController do
     )
   end
 
-  def articles(conn, _params) do
+  def articles(conn, params) do
     articles =
-      case conn.params do
+      case params do
         %{"q" => query_string} -> Directus.get_articles!(limit: 9999, query: query_string)
         _ -> Directus.get_articles!(limit: 9999)
       end
@@ -31,8 +31,27 @@ defmodule Mse25Web.PageController do
     render(conn, :articles,
       page_title: "Webblogg",
       articles: articles,
-      q: conn.params["q"],
-      nosearch?: conn.params["q"] == nil or conn.params["q"] == ""
+      q: params["q"],
+      nosearch?: params["q"] == nil or params["q"] == ""
+    )
+  end
+
+  def events(conn, params) do
+    {_, %{"title" => title, "contents" => contents}} = Directus.get_page("evenemang")
+
+    events =
+      case params do
+        %{"q" => query_string} -> Directus.get_events!(limit: 9999, query: query_string)
+        _ -> Directus.get_events!(limit: 9999)
+      end
+      |> group_annually
+
+    render(conn, :events,
+      page_title: title,
+      contents: Earmark.as_html!(contents),
+      events: events,
+      q: params["q"],
+      nosearch?: params["q"] == nil or params["q"] == ""
     )
   end
 

--- a/lib/mse25_web/controllers/page_html.ex
+++ b/lib/mse25_web/controllers/page_html.ex
@@ -5,38 +5,7 @@ defmodule Mse25Web.PageHTML do
   See the `page_html` directory for all templates available.
   """
   use Mse25Web, :html
+  import Mse25.Utils
 
   embed_templates "page_html/*"
-
-  def bandlist(bands) do
-    bands
-    |> Enum.map(fn b -> b["artists_id"]["name"] end)
-    |> Enum.join(", ")
-    |> String.replace(~r/, ([^,]+?)$/, " och \\1")
-  end
-
-  def hilights?(%{"bands" => bands, "category" => category}) do
-    _festival_band?(bands, category)
-  end
-
-  def missed?(%{"mia" => bands, "category" => category}) do
-    _festival_band?(bands, category)
-  end
-
-  def opening_acts?(%{"bands" => [_ | bands], "category" => "concert"}) do
-    not Enum.empty?(bands)
-  end
-
-  def opening_acts?(_) do
-    false
-  end
-
-  defp _festival_band?(bands, category)
-       when category in ["cruise", "openairfestival", "cityfestival", "onedayfestival"] do
-    not Enum.empty?(bands)
-  end
-
-  defp _festival_band?(_b, _c) do
-    false
-  end
 end

--- a/lib/mse25_web/controllers/page_html.ex
+++ b/lib/mse25_web/controllers/page_html.ex
@@ -5,7 +5,7 @@ defmodule Mse25Web.PageHTML do
   See the `page_html` directory for all templates available.
   """
   use Mse25Web, :html
-  import Mse25.Utils
+  import Mse25.EventHelpers
 
   embed_templates "page_html/*"
 end

--- a/lib/mse25_web/controllers/page_html.ex
+++ b/lib/mse25_web/controllers/page_html.ex
@@ -14,4 +14,29 @@ defmodule Mse25Web.PageHTML do
     |> Enum.join(", ")
     |> String.replace(~r/, ([^,]+?)$/, " och \\1")
   end
+
+  def hilights?(%{"bands" => bands, "category" => category}) do
+    _festival_band?(bands, category)
+  end
+
+  def missed?(%{"mia" => bands, "category" => category}) do
+    _festival_band?(bands, category)
+  end
+
+  def opening_acts?(%{"bands" => [_ | bands], "category" => "concert"}) do
+    not Enum.empty?(bands)
+  end
+
+  def opening_acts?(_) do
+    false
+  end
+
+  defp _festival_band?(bands, category)
+       when category in ["cruise", "openairfestival", "cityfestival", "onedayfestival"] do
+    not Enum.empty?(bands)
+  end
+
+  defp _festival_band?(_b, _c) do
+    false
+  end
 end

--- a/lib/mse25_web/controllers/page_html.ex
+++ b/lib/mse25_web/controllers/page_html.ex
@@ -7,4 +7,11 @@ defmodule Mse25Web.PageHTML do
   use Mse25Web, :html
 
   embed_templates "page_html/*"
+
+  def bandlist(bands) do
+    bands
+    |> Enum.map(fn b -> b["artists_id"]["name"] end)
+    |> Enum.join(", ")
+    |> String.replace(~r/, ([^,]+?)$/, " och \\1")
+  end
 end

--- a/lib/mse25_web/controllers/page_html/events.html.heex
+++ b/lib/mse25_web/controllers/page_html/events.html.heex
@@ -41,21 +41,26 @@
               <a href={"/" <> event["slug"]}><%= event["title"] %></a>
             </h2>
             <p><%= event["lead"] %></p>
-            <%= if not Enum.empty?(event["bands"]) do %>
+            <%= if hilights?(event) do %>
               <p>
                 Personliga höjdpunkter: <%= bandlist(event["bands"]) %>
               </p>
             <% end %>
-            <%= if not Enum.empty?(event["mia"]) do %>
+            <%= if missed?(event) do %>
               <p>
                 Band jag missade: <%= bandlist(event["mia"]) %>
+              </p>
+            <% end %>
+            <%= if opening_acts?(event) do %>
+              <p>
+                Förband: <%= event["bands"] |> Enum.drop(1) |> bandlist() %>
               </p>
             <% end %>
             <%= if event["poster"] do %>
               <img
                 loading="lazy"
                 src={"https://n.madr.se/assets/" <> event["poster"]}
-                alt="poster image"
+                alt="affisch"
                 width="150"
               />
             <% end %>

--- a/lib/mse25_web/controllers/page_html/events.html.heex
+++ b/lib/mse25_web/controllers/page_html/events.html.heex
@@ -1,0 +1,67 @@
+<header>
+  <ol class="breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+      <a href="/" rel="home">
+        <span itemprop="name">madr.se</span>
+      </a>
+      <meta itemprop="position" content="1" />
+    </li>
+  </ol>
+  <h1><%= @page_title %></h1>
+  <%= raw(@contents) %>
+  <p>
+    <%= if @nosearch? do %>
+      Gå direkt till:
+    <% end %>
+  </p>
+  <ul class="months">
+    <%= for {year, events} <- @events do %>
+      <li>
+        <a href={"#y" <> year}><%= year %></a> (<%= Enum.count(events) %>)
+      </li>
+    <% end %>
+  </ul>
+  <form method="get" action="/evenemang">
+    <p>
+      <%= if @nosearch? do %>
+        Eller
+      <% end %>
+      <label for="q">sök innehåll</label>:
+      <input type="search" value={@q} name="q" id="q" size="7" />
+      <button>Sök</button>
+    </p>
+  </form>
+  <%= for {year, events} <- @events do %>
+    <section id={"y" <> year}>
+      <h2 class="sticky"><%= year %></h2>
+      <div class="events">
+        <%= for event <- events do %>
+          <article>
+            <h2>
+              <a href={"/" <> event["slug"]}><%= event["title"] %></a>
+            </h2>
+            <p><%= event["lead"] %></p>
+            <%= if not Enum.empty?(event["bands"]) do %>
+              <p>
+                Personliga höjdpunkter: <%= bandlist(event["bands"]) %>
+              </p>
+            <% end %>
+            <%= if not Enum.empty?(event["mia"]) do %>
+              <p>
+                Band jag missade: <%= bandlist(event["mia"]) %>
+              </p>
+            <% end %>
+            <%= if event["poster"] do %>
+              <img
+                loading="lazy"
+                src={"https://n.madr.se/assets/" <> event["poster"]}
+                alt="poster image"
+                width="150"
+              />
+            <% end %>
+          </article>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+</header>

--- a/lib/mse25_web/router.ex
+++ b/lib/mse25_web/router.ex
@@ -19,15 +19,15 @@ defmodule Mse25Web.Router do
 
     get "/", PageController, :home
 
-    # get "/evenemang", EventController, :index
-    # get "/kommande-evenemang.ics", EventController, :calendar
-    # get "/event-map.js", EventController, :interactive_map
-
+    get "/evenemang", PageController, :events
     get "/webblogg", PageController, :articles
     get "/delningar", PageController, :links
 
+    # get "/kommande-evenemang.ics", EventController, :calendar
+    # get "/event-map.js", EventController, :interactive_map
     # get "/:year", TimelineController, :annual
     # get "/prenumerera.xml", TimelineController, :feed
+
     get "/*path", ItemController, :index
   end
 


### PR DESCRIPTION
This PR will create the event list and show views.

- The map is omitted for now.
- The ics feed is omitted for now.
- The Directus client is updated.
- Event helpers to tame the poor data model design is moved to a reusable module in Mse25.